### PR TITLE
fix: GetUserData function to directly use user id

### DIFF
--- a/botlists/dscbot.go
+++ b/botlists/dscbot.go
@@ -30,7 +30,7 @@ func HandleDscbot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	response := helpers.GetUserData(v)
+	response := helpers.GetUserData(v.User)
 
 	message := fmt.Sprintf("https://dsc.bot/%s/vote", v.Bot)
 

--- a/botlists/topgg.go
+++ b/botlists/topgg.go
@@ -30,7 +30,7 @@ func HandleTopgg(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	response := helpers.GetUserData(v)
+	response := helpers.GetUserData(v.User)
 
 	message := fmt.Sprintf("https://top.gg/bot/%s/vote", v.Bot)
 

--- a/helpers/japi.go
+++ b/helpers/japi.go
@@ -8,8 +8,8 @@ import (
 	"github.com/Would-You-Bot/vote-logger/types"
 )
 
-func GetUserData(v types.Vote) types.Response {
-	res, err := http.Get("https://japi.rest/discord/v1/user/" + v.User)
+func GetUserData(user_id string) types.Response {
+	res, err := http.Get("https://japi.rest/discord/v1/user/" + user_id)
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
This pull request includes changes to the `botlists` and `helpers` packages to improve the handling of user data in vote logging.

Improvements to user data handling:

* [`botlists/dscbot.go`](diffhunk://#diff-4e609cfaf6c0a85f0991c0b499f0506dc5feb9c2c9ca98f3029d6d0bd43844cfL33-R33): Modified the `HandleDscbot` function to pass `v.User` instead of `v` to the `GetUserData` helper function.
* [`botlists/topgg.go`](diffhunk://#diff-3e8327ed380cc8aa2c79686bb21f9b06182e17ce2d91b1b4982064a6292bf1baL33-R33): Modified the `HandleTopgg` function to pass `v.User` instead of `v` to the `GetUserData` helper function.
* [`helpers/japi.go`](diffhunk://#diff-5ee5366119523b49174260a4ae09fe278de5d9392ef4434a3c34f34c3c6c5657L11-R12): Changed the `GetUserData` function to accept a `user_id` string instead of a `Vote` type, and updated the HTTP request to use the `user_id`.