### PR TITLE
Use newly provided ListingId instead of BotId

### DIFF
--- a/botlists/dscbot.go
+++ b/botlists/dscbot.go
@@ -7,8 +7,13 @@ import (
 
 	"github.com/Would-You-Bot/vote-logger/config"
 	"github.com/Would-You-Bot/vote-logger/helpers"
-	"github.com/Would-You-Bot/vote-logger/types"
 )
+
+type DscWebhookData struct {
+	ListingId string `json:"listing_id"`
+	BotId     string `json:"bot_id"`
+	UserId    string `json:"user_id"`
+}
 
 func HandleDscbot(w http.ResponseWriter, r *http.Request) {
 	fmt.Println("Received vote from dsc.bot")
@@ -21,7 +26,7 @@ func HandleDscbot(w http.ResponseWriter, r *http.Request) {
 
 	dec := json.NewDecoder(r.Body)
 
-	var v types.Vote
+	var v DscWebhookData
 
 	err := dec.Decode(&v)
 	if err != nil {
@@ -30,13 +35,13 @@ func HandleDscbot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	response := helpers.GetUserData(v.User)
+	response := helpers.GetUserData(v.UserId)
 
-	message := fmt.Sprintf("https://dsc.bot/%s/vote", v.Bot)
+	message := fmt.Sprintf("https://dsc.bot/%s/vote", v.ListingId)
 
 	helpers.SendVoteWebhook(response, message)
 
 	w.WriteHeader(http.StatusOK)
 
-	fmt.Println("Vote received from " + v.User + " for " + v.Bot)
+	fmt.Println("Vote received from " + v.UserId + " for " + v.BotId)
 }

--- a/botlists/topgg.go
+++ b/botlists/topgg.go
@@ -7,8 +7,12 @@ import (
 
 	"github.com/Would-You-Bot/vote-logger/config"
 	"github.com/Would-You-Bot/vote-logger/helpers"
-	"github.com/Would-You-Bot/vote-logger/types"
 )
+
+type TopWebhookData struct {
+	Bot  string `json:"bot"`
+	User string `json:"user"`
+}
 
 func HandleTopgg(w http.ResponseWriter, r *http.Request) {
 	fmt.Println("Received vote from top.gg")
@@ -21,7 +25,7 @@ func HandleTopgg(w http.ResponseWriter, r *http.Request) {
 
 	dec := json.NewDecoder(r.Body)
 
-	var v types.Vote
+	var v TopWebhookData
 
 	err := dec.Decode(&v)
 	if err != nil {

--- a/types/vote.go
+++ b/types/vote.go
@@ -1,6 +1,0 @@
-package types
-
-type Vote struct {
-	Bot       string `json:"bot"`
-	User      string `json:"user"`
-}


### PR DESCRIPTION
This pull request includes changes to refactor the vote handling for different bot lists by introducing specific data structures for each bot list and removing the shared `Vote` type. The most important changes include defining new data structures for `dscbot` and `topgg`, updating the vote handling functions to use these new structures, and removing the now-unused `Vote` type.

Refactoring vote handling:

* [`botlists/dscbot.go`](diffhunk://#diff-4e609cfaf6c0a85f0991c0b499f0506dc5feb9c2c9ca98f3029d6d0bd43844cfL10-R17): Defined a new `DscWebhookData` structure and updated the `HandleDscbot` function to use this structure instead of the `types.Vote` type. [[1]](diffhunk://#diff-4e609cfaf6c0a85f0991c0b499f0506dc5feb9c2c9ca98f3029d6d0bd43844cfL10-R17) [[2]](diffhunk://#diff-4e609cfaf6c0a85f0991c0b499f0506dc5feb9c2c9ca98f3029d6d0bd43844cfL24-R29) [[3]](diffhunk://#diff-4e609cfaf6c0a85f0991c0b499f0506dc5feb9c2c9ca98f3029d6d0bd43844cfL33-R46)
* [`botlists/topgg.go`](diffhunk://#diff-3e8327ed380cc8aa2c79686bb21f9b06182e17ce2d91b1b4982064a6292bf1baL10-R16): Defined a new `TopWebhookData` structure and updated the `HandleTopgg` function to use this structure instead of the `types.Vote` type. [[1]](diffhunk://#diff-3e8327ed380cc8aa2c79686bb21f9b06182e17ce2d91b1b4982064a6292bf1baL10-R16) [[2]](diffhunk://#diff-3e8327ed380cc8aa2c79686bb21f9b06182e17ce2d91b1b4982064a6292bf1baL24-R28)

Code cleanup:

* [`types/vote.go`](diffhunk://#diff-bbb9bd0af4005675e967c0257febe349cf74283b3e74f216ea59bfd9819d499dL1-L6): Removed the `Vote` type as it is no longer used after the refactoring.